### PR TITLE
0005 jail: make '-cm' run 'command=' in modify case as well

### DIFF
--- a/usr.sbin/jail/config.c
+++ b/usr.sbin/jail/config.c
@@ -471,6 +471,25 @@ add_param(struct cfjail *j, const struct cfparam *p, enum intparam ipnum,
 }
 
 /*
+ * Return if nopersist parameter is explicitly provided.
+ */
+int
+transition_to_nopersist(struct cfjail *j)
+{
+	struct jailparam *jp;
+
+	// check if outcome of params sequence is that it's still persist
+	if (bool_param(j->intparams[KP_PERSIST]))
+		return 0;
+
+	for (jp = j->jp; jp < j->jp + j->njp; jp++)
+		if (equalopts(jp->jp_name, "persist"))
+			return 1;
+
+	return 0;
+}
+
+/*
  * Return if a boolean parameter exists and is true.
  */
 int

--- a/usr.sbin/jail/jailp.h
+++ b/usr.sbin/jail/jailp.h
@@ -218,6 +218,7 @@ extern void include_config(void *scanner, const char *cfname);
 extern struct cfjail *add_jail(void);
 extern void add_param(struct cfjail *j, const struct cfparam *p,
     enum intparam ipnum, const char *value);
+extern int transition_to_nopersist(struct cfjail *j);
 extern int bool_param(const struct cfparam *p);
 extern int int_param(const struct cfparam *p, int *ip);
 extern const char *string_param(const struct cfparam *p);


### PR DESCRIPTION
Currently 'jail -cm command=<cmd>' runs <cmd> only in create '-c' case.