### PR TITLE
0015 netlink: fix snl_writer and linear_buffer re-allocation logic

### DIFF
--- a/sys/netlink/netlink_snl.h
+++ b/sys/netlink/netlink_snl.h
@@ -1036,14 +1036,13 @@ snl_realloc_msg_buffer(struct snl_writer *nw, size_t sz)
 	if (nw->error)
 		return (false);
 
-	void *new_base = snl_allocz(nw->ss, new_size);
-	if (new_base == NULL) {
+	if (snl_allocz(nw->ss, new_size) == NULL) {
 		nw->error = true;
 		return (false);
 	}
 	nw->size = new_size;
 
-	new_base = nw->ss->lb->base;
+	void *new_base = nw->ss->lb->base;
 	if (new_base != nw->base) {
 		memcpy(new_base, nw->base, nw->offset);
 		if (nw->hdr != NULL) {

--- a/sys/netlink/netlink_snl.h
+++ b/sys/netlink/netlink_snl.h
@@ -1041,14 +1041,19 @@ snl_realloc_msg_buffer(struct snl_writer *nw, size_t sz)
 		nw->error = true;
 		return (false);
 	}
+	nw->size = new_size;
 
-	memcpy(new_base, nw->base, nw->offset);
-	if (nw->hdr != NULL) {
-		int hdr_off = (char *)(nw->hdr) - nw->base;
+	new_base = nw->ss->lb->base;
+	if (new_base != nw->base) {
+		memcpy(new_base, nw->base, nw->offset);
+		if (nw->hdr != NULL) {
+			int hdr_off = (char *)(nw->hdr) - nw->base;
 
-		nw->hdr = (struct nlmsghdr *)(void *)((char *)new_base + hdr_off);
+			nw->hdr = (struct nlmsghdr *)
+			    (void *)((char *)new_base + hdr_off);
+		}
+		nw->base = new_base;
 	}
-	nw->base = new_base;
 
 	return (true);
 }


### PR DESCRIPTION
- Use correct base pointer after re-allocation, it avoids buffer
  overflows.

- Maintain correct snl_writer.size, it avoids redundant memory
  allocation, e.g. need for ~1k bytes may end up with ~32k linear_buffer
  actually allocated.

It fixes pfctl regression at least for armv7 after addrule logic
migration to netlink:
  https://github.com/ihoro/freebsd-src/commit/ffbf25951e7b7f867989b621b2c07e9dad9441fb ("pf: convert rule addition to netlink")
Add rule command creates bigger than default size netlink requests what
triggers re-allocation logic.