### PR TITLE
tests: Switch bin/hostname/hostname_test to execenv=jail

### DIFF
--- a/bin/hostname/tests/hostname_test.sh
+++ b/bin/hostname/tests/hostname_test.sh
@@ -42,9 +42,6 @@ test_jail_conf='%%test_jail_name%% {
 
 init()
 {
-    if ! which -s jail; then
-        atf_skip "This test requires jail"
-    fi
     echo "${test_jail_conf}" | \
 	    sed -e "s/%%test_jail_name%%/${test_jail_name}/" > "./jail.conf"
     jail -f "./jail.conf" -c ${test_jail_name}
@@ -61,6 +58,7 @@ basic_head()
 {
     atf_set require.user root
     atf_set "descr" "basic test for getting hostname"
+    atf_set execenv jail
 }
 basic_body()
 {
@@ -81,9 +79,6 @@ basic_body()
 }
 basic_cleanup()
 {
-    if ! which -s jail; then
-        atf_skip "This test requires jail"
-    fi
     recycle
 }
 


### PR DESCRIPTION
Kyua skips tests based on the jail execution environment if a system is built WITHOUT_JAIL. Thus, the test case does not need to handle it.