### PR TITLE
kyua: Pass unprivileged user config prop to ATF using all known names

### DIFF
--- a/contrib/kyua/engine/scheduler.cpp
+++ b/contrib/kyua/engine/scheduler.cpp
@@ -1632,7 +1632,10 @@ scheduler::generate_config(const config::tree& user_config,
     if (user_config.is_set("unprivileged_user")) {
         const passwd::user& user =
             user_config.lookup< engine::user_node >("unprivileged_user");
+	// The property is duplicated using both ATF and Kyua naming styles
+	// for better UX.
         props["unprivileged-user"] = user.name;
+        props["unprivileged_user"] = user.name;
     }
 
     return props;


### PR DESCRIPTION
```
kyua: Pass unprivileged user config prop to ATF using all known names

Kyua and ATF speak different naming styles. In this case, an
unprivileged user property can be named with underscore on the Kyua
side, and with a minus on the ATF side. Sometimes it is not obvious
which style should be used in which situation. For instance, a test case
may require this configuration property being set using require.config.
Also, a test case may want to read the property using something like
atf_tc_get_config_var(). Which names should be used in these cases?
From the perspective of the original code, it is expected to be this:
    require.config unprivileged-user
    atf_tc_get_config_var(tc, "unprivileged-user")

But, as long as Kyua is the main interface, its users expect to work
with kyua.conf(5), which says that it must be named as unprivileged_user
(with underscore). As a result, test authors tend to this instead:
    require.config unprivileged_user
    atf_tc_get_config_var(tc, "unprivileged_user")

Kyua already has hacks to understand both unprivileged_user and
unprivileged-user coming from require.config. And this patch covers the
missing second part -- make Kyua pass both names back to ATF as two
identical configuration properties named different ways.
```