### PR TITLE
0061 kyua: Add "kyua debug -p" option

### DIFF
--- a/contrib/kyua/doc/kyua-debug.1.in
+++ b/contrib/kyua/doc/kyua-debug.1.in
@@ -25,7 +25,7 @@
 .\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 .\" OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd October 13, 2014
+.Dd March 25, 2025
 .Dt KYUA-DEBUG 1
 .Os
 .Sh NAME
@@ -35,6 +35,8 @@
 .Nm
 .Op Fl -build-root Ar path
 .Op Fl -kyuafile Ar file
+.Op Fl -pause-before-cleanup-upon-fail
+.Op Fl -pause-before-cleanup
 .Op Fl -stdout Ar path
 .Op Fl -stderr Ar path
 .Ar test_case
@@ -84,6 +86,23 @@ Specifies the Kyuafile to process.
 Defaults to
 .Pa Kyuafile
 file in the current directory.
+.It Fl -pause-before-cleanup-upon-fail , Fl p
+Causes Kyua to pause right before the test cleanup routine is invoked if the
+test fails.
+When paused, Kyua waits for input on stdin, and any key press resumes
+execution.
+.sp
+This can be useful for debugging system or end-to-end tests
+which alter the system by creating artifacts such as files, network
+interfaces, routing entries, firewall configuration, containers, etc.
+This flag makes it possible to preserve such artifacts immediately after a test
+failure, simplifying debugging.
+Otherwise, these artifacts would be removed by the test cleanup routine or
+by Kyua built-in cleanup mechanism.
+.It Fl -pause-before-cleanup
+The unconditional variant of the previous option.
+This can be helpful for reproducing the infrastructure or fixture of a passing
+test for further development or additional analysis.
 .It Fl -stderr Ar path
 Specifies the file to which to send the standard error of the test
 program's body.

--- a/contrib/kyua/drivers/debug_test.cpp
+++ b/contrib/kyua/drivers/debug_test.cpp
@@ -63,7 +63,8 @@ using utils::optional;
 ///
 /// \returns A structure with all results computed by this driver.
 drivers::debug_test::result
-drivers::debug_test::drive(const fs::path& kyuafile_path,
+drivers::debug_test::drive(engine::debugger_ptr debugger,
+                           const fs::path& kyuafile_path,
                            const optional< fs::path > build_root,
                            const engine::test_filter& filter,
                            const config::tree& user_config,
@@ -91,6 +92,10 @@ drivers::debug_test::drive(const fs::path& kyuafile_path,
     INV(match && scanner.done());
     const model::test_program_ptr test_program = match.get().first;
     const std::string& test_case_name = match.get().second;
+
+    const model::test_case test_case = test_program->find(test_case_name);
+    if (debugger)
+        test_case.attach_debugger(debugger);
 
     scheduler::result_handle_ptr result_handle = handle.debug_test(
         test_program, test_case_name, user_config,

--- a/contrib/kyua/engine/debugger.hpp
+++ b/contrib/kyua/engine/debugger.hpp
@@ -1,4 +1,4 @@
-// Copyright 2011 The Kyua Authors.
+// Copyright 2025 The Kyua Authors.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -26,58 +26,46 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/// \file drivers/debug_test.hpp
-/// Driver to run a single test in a controlled manner.
-///
-/// This driver module implements the logic to execute a particular test
-/// with hooks into the runtime procedure.  This is to permit debugging the
-/// behavior of the test.
+/// \file engine/debugger.hpp
+/// The interface between the engine and the users outside.
 
-#if !defined(DRIVERS_DEBUG_TEST_HPP)
-#define DRIVERS_DEBUG_TEST_HPP
+#if !defined(ENGINE_DEBUGGER_HPP)
+#define ENGINE_DEBUGGER_HPP
 
-#include "engine/debugger.hpp"
-#include "engine/filters.hpp"
-#include "model/test_result.hpp"
-#include "utils/config/tree_fwd.hpp"
-#include "utils/fs/path_fwd.hpp"
+#include "model/test_case_fwd.hpp"
+#include "model/test_program_fwd.hpp"
+#include "model/test_result_fwd.hpp"
 #include "utils/optional_fwd.hpp"
+#include "utils/process/executor_fwd.hpp"
 
-using engine::debugger;
+namespace executor = utils::process::executor;
 
-namespace drivers {
-namespace debug_test {
+using utils::optional;
 
 
-/// Tuple containing the results of this driver.
-class result {
+namespace engine {
+
+
+/// Abstract debugger interface.
+class debugger {
 public:
-    /// A filter matching the executed test case only.
-    engine::test_filter test_case;
+    debugger() {}
+    virtual ~debugger() {}
 
-    /// The result of the test case.
-    model::test_result test_result;
-
-    /// Initializer for the tuple's fields.
-    ///
-    /// \param test_case_ The matched test case.
-    /// \param test_result_ The result of the test case.
-    result(const engine::test_filter& test_case_,
-           const model::test_result& test_result_) :
-        test_case(test_case_),
-        test_result(test_result_)
-    {
-    }
+    /// Called right before test cleanup.
+    virtual void before_cleanup(
+        const model::test_program_ptr&,
+        const model::test_case&,
+        optional< model::test_result >&,
+        executor::exit_handle&) const = 0;
 };
 
 
-result drive(std::shared_ptr< debugger >,
-             const utils::fs::path&, const utils::optional< utils::fs::path >,
-             const engine::test_filter&, const utils::config::tree&,
-             const utils::fs::path&, const utils::fs::path&);
+/// Pointer to a debugger implementation.
+typedef std::shared_ptr< debugger > debugger_ptr;
 
 
-}  // namespace debug_test
-}  // namespace drivers
+}  // namespace engine
 
-#endif  // !defined(DRIVERS_DEBUG_TEST_HPP)
+
+#endif  // !defined(ENGINE_DEBUGGER_HPP)

--- a/contrib/kyua/engine/scheduler.cpp
+++ b/contrib/kyua/engine/scheduler.cpp
@@ -39,6 +39,7 @@ extern "C" {
 #include <stdexcept>
 
 #include "engine/config.hpp"
+#include "engine/debugger.hpp"
 #include "engine/exceptions.hpp"
 #include "engine/execenv/execenv.hpp"
 #include "engine/requirements.hpp"
@@ -1396,8 +1397,15 @@ scheduler::scheduler_handle::wait_any(void)
                                  handle.stderr_file());
         }
 
+        std::shared_ptr< debugger > debugger = test_case.get_debugger();
+        if (debugger) {
+            debugger->before_cleanup(test_data->test_program, test_case,
+                result, handle);
+        }
+
         if (test_data->needs_cleanup) {
             INV(test_case.get_metadata().has_cleanup());
+
             // The test body has completed and we have processed it.  If there
             // is a cleanup routine, trigger it now and wait for any other test
             // completion.  The caller never knows about cleanup routines.

--- a/contrib/kyua/model/test_case.cpp
+++ b/contrib/kyua/model/test_case.cpp
@@ -60,6 +60,9 @@ struct model::test_case::impl : utils::noncopyable {
     /// Fake result to return instead of running the test case.
     optional< model::test_result > fake_result;
 
+    /// Optional pointer to a debugger attached.
+    engine::debugger_ptr debugger;
+
     /// Constructor.
     ///
     /// \param name_ The name of the test case within the test program.
@@ -230,6 +233,24 @@ const model::metadata&
 model::test_case::get_raw_metadata(void) const
 {
     return _pimpl->md;
+}
+
+
+/// Attach a debugger to the test case.
+void
+model::test_case::attach_debugger(engine::debugger_ptr debugger) const
+{
+    _pimpl->debugger = debugger;
+}
+
+
+/// Gets the optional pointer to a debugger.
+///
+/// \return An optional pointer to a debugger.
+engine::debugger_ptr
+model::test_case::get_debugger() const
+{
+    return _pimpl->debugger;
 }
 
 

--- a/contrib/kyua/model/test_case.hpp
+++ b/contrib/kyua/model/test_case.hpp
@@ -38,10 +38,12 @@
 #include <ostream>
 #include <string>
 
+#include "engine/debugger.hpp"
 #include "model/metadata_fwd.hpp"
 #include "model/test_result_fwd.hpp"
 #include "utils/noncopyable.hpp"
 #include "utils/optional_fwd.hpp"
+
 
 namespace model {
 
@@ -70,6 +72,9 @@ public:
     metadata get_metadata(void) const;
     const metadata& get_raw_metadata(void) const;
     utils::optional< test_result > fake_result(void) const;
+
+    void attach_debugger(engine::debugger_ptr) const;
+    engine::debugger_ptr get_debugger() const;
 
     bool operator==(const test_case&) const;
     bool operator!=(const test_case&) const;


### PR DESCRIPTION
It allows the test engine to be paused right before the test cleanup routine to help with test debugging.